### PR TITLE
Fixes getStaticPaths for new slugs

### DIFF
--- a/pages/work/[slug].tsx
+++ b/pages/work/[slug].tsx
@@ -125,7 +125,7 @@ export async function getStaticPaths() {
     paths: slugs.map(slug => ({
       params: {slug},
     })),
-    fallback: false,
+    fallback: 'blocking',
   };
 }
 


### PR DESCRIPTION
`getStaticPaths` had a `fallback: false` which was causing issues when adding new posts